### PR TITLE
Support of a dual bootloader

### DIFF
--- a/ports/stm32/boards/STM32F469DISC/mpconfigboard.mk
+++ b/ports/stm32/boards/STM32F469DISC/mpconfigboard.mk
@@ -4,10 +4,20 @@ CMSIS_MCU = STM32F469xx
 MICROPY_FLOAT_IMPL = double
 AF_FILE = boards/stm32f469_af.csv
 
-# When not using Mboot the ISR text goes first, then the rest, no file system
+ifeq ($(USE_MBOOT),1)
+# When using Mboot all the text goes together after the filesystem
+LD_FILES = boards/stm32f469xi.ld boards/common_blifs.ld
+TEXT0_ADDR = 0x08020000
+else ifeq ($(USE_DBOOT),1)
+# When using dual Bootloader all the text goes together after the filesystem
+LD_FILES = boards/stm32f469xi_dboot.ld boards/common_blifs.ld
+TEXT0_ADDR = 0x08020000
+else
+# When not using Mboot the ISR text goes first, then the rest after the filesystem
 LD_FILES = boards/stm32f469xi.ld boards/common_ifs.ld
 TEXT0_ADDR = 0x08000000
 TEXT1_ADDR = 0x08008000
+endif
 
 # MicroPython settings
 MICROPY_PY_USSL = 1

--- a/ports/stm32/boards/stm32f469xi_dboot.ld
+++ b/ports/stm32/boards/stm32f469xi_dboot.ld
@@ -1,0 +1,31 @@
+/*
+    GNU linker script for STM32F469xI (2Mbyte) with dual Bootloader
+*/
+
+/* Specify the memory areas */
+MEMORY
+{
+    FLASH (rx)       : ORIGIN = 0x08000000, LENGTH = 2048K /* Entire flash */
+    FLASH_START (rx) : ORIGIN = 0x08000000, LENGTH = 32K   /* Sectors 0, 1 */
+    FLASH_FS (r)     : ORIGIN = 0x08008000, LENGTH = 96K   /* Sectors 2 - 4 */
+    FLASH_TEXT (rx)  : ORIGIN = 0x08020000, LENGTH = 1664K /* Sectors 5 - 21 */
+    FLASH_BOOT1 (rx) : ORIGIN = 0x081C0000, LENGTH = 128K  /* Sector 22 */
+    FLASH_BOOT2 (rx) : ORIGIN = 0x081E0000, LENGTH = 128K  /* Sector 23 */
+    DTCM (rw)        : ORIGIN = 0x10000000, LENGTH = 64K   /* CCM RAM used for storage cache */
+    RAM (xrw)        : ORIGIN = 0x20000000, LENGTH = 320K  /* SRAM1, SRAM2, SRAM3 */
+}
+
+/* produce a link error if there is not this amount of RAM for these sections */
+_minimum_stack_size = 2K;
+_minimum_heap_size = 16K;
+
+/* Define the stack.  The stack is full descending so begins just above last byte
+   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
+_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
+_sstack = _estack - 16K; /* tunable */
+
+/* RAM extents for the garbage collector */
+_ram_start = ORIGIN(RAM);
+_ram_end = ORIGIN(RAM) + LENGTH(RAM);
+_heap_start = _ebss; /* heap starts just after statically allocated memory */
+_heap_end = _sstack;


### PR DESCRIPTION
This modification adds support of a dual bootloader: satart-up code + 2
copies of bootloader. To build for the dual bootloader add USE_DBOOT=1
to Make's command line.